### PR TITLE
Add linting and enforce on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,26 @@ name: CI
 on:
   push:
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.20.0'
+      - name: Lint
+        run: |
+          go install golang.org/x/tools/cmd/goimports@latest
+          go install github.com/daixiang0/gci@latest
+
+          goimports -w .
+          gci -w .
+
+          if [ -n "$(git status --porcelain)" ]; then
+            echo '🧼 To fix this check, install required tooling and run "goimports -w . && gci -w .;"'
+            git status # Show the files that failed to pass the check.
+            exit 1
+          fi
   test:
     strategy:
       fail-fast: false
@@ -15,16 +35,3 @@ jobs:
           go-version: '>=1.20.0'
       - name: Test
         run: go test -v ./... -cover
-      - name: Lint
-        run: |
-          go install golang.org/x/tools/cmd/goimports@latest
-          go install github.com/daixiang0/gci@latest
-          
-          goimports -w .
-          gci -w .
-          
-          if [ -n "$(git status --porcelain)" ]; then
-            echo '🧼 To fix this check, install required tooling and run "goimports -w . && gci -w .;"'
-            git status # Show the files that failed to pass the check.
-            exit 1
-          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,10 @@ jobs:
           go install github.com/daixiang0/gci@latest
 
           goimports -w .
-          gci -w .
+          gci write .
 
           if [ -n "$(git status --porcelain)" ]; then
-            echo '🧼 To fix this check, install required tooling and run "goimports -w . && gci -w .;"'
+            echo '🧼 To fix this check, install required tooling and run "goimports -w . && gci write .;"'
             git status # Show the files that failed to pass the check.
             exit 1
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,4 +13,16 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: '>=1.20.0'
-      - run: go test -v ./... -cover
+      - name: Test & Lint
+        run: |
+          # Tests
+          go test -v ./... -cover
+          
+          # Lint
+          goimports -w .
+          
+          if [ -n "$(git status --porcelain)" ]; then
+            echo '🧼 To fix this check, run "goimports -w .;"'
+            git status # Show the files that failed to pass the check.
+            exit 1
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,16 +13,18 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: '>=1.20.0'
-      - name: Test & Lint
+      - name: Test
+        run: go test -v ./... -cover
+      - name: Lint
         run: |
-          # Tests
-          go test -v ./... -cover
+          go install golang.org/x/tools/cmd/goimports@latest
+          go install github.com/daixiang0/gci@latest
           
-          # Lint
           goimports -w .
+          gci -w .
           
           if [ -n "$(git status --porcelain)" ]; then
-            echo '🧼 To fix this check, run "goimports -w .;"'
+            echo '🧼 To fix this check, install required tooling and run "goimports -w . && gci -w .;"'
             git status # Show the files that failed to pass the check.
             exit 1
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,10 @@
 
 ## 💽 Development
 
+Run the setup script:
+
+    ./scripts/setup.sh
+
 Run the following command to run the application:
 
     go run github.com/techygrrrl/timerrr
@@ -34,16 +38,16 @@ Write any operating-specific tests in a file for that operating system, e.g. `os
 
 ### 🧹🕸 Linting
 
-Use `goimports` for formatting and linting.
+Use [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) for formatting and linting, and [gci](https://github.com/daixiang0/gci) for import order.
 
 Install it:
 
     go install golang.org/x/tools/cmd/goimports@latest
+    go install github.com/daixiang0/gci@latest
 
 Run it:
 
-    goimports -w .
-
+    goimports -w . && gci write .
 
 ## 🚀 Releasing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,7 @@
 - [💽 Development](#-development)
 - [🖥 Requirements](#-requirements)
 - [✅ Testing](#-testing)
+  - [🧹🕸 Linting](#-linting)
 - [🚀 Releasing](#-releasing)
 
 
@@ -29,6 +30,19 @@ To run tests with coverage run:
     go test -v ./... -cover
 
 Write any operating-specific tests in a file for that operating system, e.g. `os_utils_linux_test.go` will only run on Linux.
+
+
+### 🧹🕸 Linting
+
+Use `goimports` for formatting and linting.
+
+Install it:
+
+    go install golang.org/x/tools/cmd/goimports@latest
+
+Run it:
+
+    goimports -w .
 
 
 ## 🚀 Releasing

--- a/cli/cmd/add.go
+++ b/cli/cmd/add.go
@@ -147,7 +147,8 @@ func (m AddModel) View() string {
 }
 
 // TODO: Fix warning?
-//		Struct AddModel has methods on both value and pointer receivers. Such usage is not recommended by the Go Documentation.
+//
+//	Struct AddModel has methods on both value and pointer receivers. Such usage is not recommended by the Go Documentation.
 func (m *AddModel) updateInputs(msg tea.Msg) tea.Cmd {
 	cmds := make([]tea.Cmd, len(m.inputs))
 

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/sh
+if [[ $(gci diff .) ]]; then
+  echo '💥 Lint error: gci'
+  exit 1
+fi
+
+if [[ $(goimports -d .) ]]; then
+  echo '💥 Lint error: goimports'
+  exit 1
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+cp scripts/pre-commit .git/hooks/pre-commit

--- a/utils/file_utils.go
+++ b/utils/file_utils.go
@@ -2,9 +2,10 @@ package utils
 
 import (
 	"encoding/json"
-	"errors"
 	"os"
 	"path/filepath"
+
+	"errors"
 
 	"github.com/techygrrrl/timerrr/models"
 )

--- a/utils/file_utils.go
+++ b/utils/file_utils.go
@@ -2,10 +2,9 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
-
-	"errors"
 
 	"github.com/techygrrrl/timerrr/models"
 )


### PR DESCRIPTION
Adds linting with goimports and gci (for import ordering).

Adds a pre-commit hook to help the developer. Can be skipped with `--no-verify` but the build will still break.

Linting only runs on Ubuntu.